### PR TITLE
fix: infinite loop as collectionIndex remains the same

### DIFF
--- a/packages/loki-fs-structured-adapter/main.ts
+++ b/packages/loki-fs-structured-adapter/main.ts
@@ -197,7 +197,7 @@ export class LokiFsStructuredAdapter {
       internalCollectionIndex += 1;
       // if there are more collections, load the next one
       if (internalCollectionIndex < this.dbref.collections.length) {
-        this.loadNextCollection(databaseName, collectionIndex, callback);
+        this.loadNextCollection(databaseName, internalCollectionIndex, callback);
       }
       // otherwise we are done, callback to loadDatabase so it can return the
       // new db object representation.


### PR DESCRIPTION
I'm not sure what @recative/studio is. But this PR is a fix for https://github.com/recative/studio/issues/1. Thanks a ton for fixing the cannot get `collections` of `null` value error in the main FsStructuredAdapter file! 

Sorry about not including any tests as well. You might want to include one if you agree that this is an error. 🙏🏽 